### PR TITLE
Allow specifying policy in the top-level module line

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,6 @@ macOS:
 - Support embedding gomodjail in a target program
 - Apply landlock in addition to seccomp. Depends on `SECCOMP_IOCTL_NOTIF_ADDFD`.
 - Modify the source code of the Go runtime, so as to remove necessity of using `seccomp` (Linux) and `DYLD_INSERT_LIBRARIES` (macOS).
+
+## Additional documents
+- [`docs/syntax.md`](./docs/syntax.md): syntax

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -1,0 +1,32 @@
+# Syntax of `// gomodjail:...` comments
+
+e.g.,
+```go-module
+// gomodjail:confined
+module example.com/foo
+
+go 1.23
+
+require (
+        example.com/mod100 v1.2.3
+        example.com/mod101 v1.2.3 // gomodjail:unconfined
+        example.com/mod102 v1.2.3
+        // gomodjail:unconfined
+        example.com/mod103 v1.2.3
+)
+
+require (
+        // gomodjail:unconfined
+        example.com/mod200 v1.2.3 // indirect
+        example.com/mod201 v1.2.3 // indirect
+)
+
+// policy cannot be specified here because the parser ignores
+// the comment lines here
+require (
+)
+```
+
+This makes the following modules confined: `mod100`, `mod102`, and `mod201`.
+
+The version numbers are ignored.

--- a/examples/profiles/docker-26.1.3.mod
+++ b/examples/profiles/docker-26.1.3.mod
@@ -3,6 +3,7 @@
 // From https://github.com/docker/cli/blob/v26.1.3/vendor.mod
 // LICENSE: https://github.com/docker/cli/blob/v26.1.3/LICENSE (Apache License 2.0)
 
+// gomodjail:confined
 module github.com/docker/cli
 
 // 'vendor.mod' enables use of 'go mod vendor' to managed 'vendor/' directory.
@@ -12,94 +13,98 @@ module github.com/docker/cli
 go 1.21
 
 require (
-	dario.cat/mergo v1.0.0 // gomodjail:confined
-	github.com/containerd/containerd v1.7.15 // gomodjail:confined
-	github.com/creack/pty v1.1.21 // gomodjail:confined
-	github.com/distribution/reference v0.5.0 // gomodjail:confined
-	github.com/docker/distribution v2.8.3+incompatible // gomodjail:confined
-	github.com/docker/docker v26.1.3-0.20240515073302-8e96db1c328d+incompatible
-	github.com/docker/docker-credential-helpers v0.8.1 // gomodjail:confined
-	github.com/docker/go-connections v0.5.0
-	github.com/docker/go-units v0.5.0 // gomodjail:confined
-	github.com/fvbommel/sortorder v1.0.2 // gomodjail:confined
-	github.com/gogo/protobuf v1.3.2 // gomodjail:confined
-	github.com/google/go-cmp v0.6.0 // gomodjail:confined
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // gomodjail:confined
-	github.com/mattn/go-runewidth v0.0.15 // gomodjail:confined
-	github.com/mitchellh/mapstructure v1.5.0 // gomodjail:confined
-	github.com/moby/patternmatcher v0.6.0 // gomodjail:confined
-	github.com/moby/swarmkit/v2 v2.0.0-20240227173239-911c97650f2e // gomodjail:confined
-	github.com/moby/sys/sequential v0.5.0 // gomodjail:confined
-	github.com/moby/sys/signal v0.7.0 // gomodjail:confined
-	github.com/moby/term v0.5.0
-	github.com/morikuni/aec v1.0.0 // gomodjail:confined
-	github.com/opencontainers/go-digest v1.0.0 // gomodjail:confined
-	github.com/opencontainers/image-spec v1.1.0-rc5 // gomodjail:confined
-	github.com/pkg/errors v0.9.1 // gomodjail:confined
-	github.com/sirupsen/logrus v1.9.3 // gomodjail:confined
-	github.com/spf13/cobra v1.8.0
-	github.com/spf13/pflag v1.0.5 // gomodjail:confined
-	github.com/theupdateframework/notary v0.7.1-0.20210315103452-bf96a202a09a // gomodjail:confined
-	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // gomodjail:confined
-	github.com/xeipuuv/gojsonschema v1.2.0 // gomodjail:confined
-	go.opentelemetry.io/otel v1.21.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0 // gomodjail:confined
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0 // gomodjail:confined
-	go.opentelemetry.io/otel/metric v1.21.0
-	go.opentelemetry.io/otel/sdk v1.21.0
-	go.opentelemetry.io/otel/sdk/metric v1.21.0
-	go.opentelemetry.io/otel/trace v1.21.0 // gomodjail:confined
-	golang.org/x/sync v0.6.0
-	golang.org/x/sys v0.18.0
-	golang.org/x/term v0.18.0 // gomodjail:confined
-	golang.org/x/text v0.14.0 // gomodjail:confined
-	gopkg.in/yaml.v2 v2.4.0 // gomodjail:confined
-	gotest.tools/v3 v3.5.1 // gomodjail:confined
-	tags.cncf.io/container-device-interface v0.6.2 // gomodjail:confined
+	dario.cat/mergo v1.0.0
+	github.com/containerd/containerd v1.7.15
+	github.com/creack/pty v1.1.21
+	github.com/distribution/reference v0.5.0
+	github.com/docker/distribution v2.8.3+incompatible
+	github.com/docker/docker v26.1.3-0.20240515073302-8e96db1c328d+incompatible // gomodjail:unconfined
+	github.com/docker/docker-credential-helpers v0.8.1
+	github.com/docker/go-connections v0.5.0 // gomodjail:unconfined
+	github.com/docker/go-units v0.5.0
+	github.com/fvbommel/sortorder v1.0.2
+	github.com/gogo/protobuf v1.3.2
+	github.com/google/go-cmp v0.6.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/mattn/go-runewidth v0.0.15
+	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/patternmatcher v0.6.0
+	github.com/moby/swarmkit/v2 v2.0.0-20240227173239-911c97650f2e
+	github.com/moby/sys/sequential v0.5.0
+	github.com/moby/sys/signal v0.7.0
+	github.com/moby/term v0.5.0 // gomodjail:unconfined
+	github.com/morikuni/aec v1.0.0
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.0-rc5
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.9.3
+	github.com/spf13/cobra v1.8.0 // gomodjail:unconfined
+	github.com/spf13/pflag v1.0.5
+	github.com/theupdateframework/notary v0.7.1-0.20210315103452-bf96a202a09a
+	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d
+	github.com/xeipuuv/gojsonschema v1.2.0
+	go.opentelemetry.io/otel v1.21.0 // gomodjail:unconfined
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0
+	go.opentelemetry.io/otel/metric v1.21.0 // gomodjail:unconfined
+	go.opentelemetry.io/otel/sdk v1.21.0 // gomodjail:unconfined
+	go.opentelemetry.io/otel/sdk/metric v1.21.0 // gomodjail:unconfined
+	go.opentelemetry.io/otel/trace v1.21.0
+	golang.org/x/sync v0.6.0 // gomodjail:unconfined
+	golang.org/x/sys v0.18.0 // gomodjail:unconfined
+	golang.org/x/term v0.18.0
+	golang.org/x/text v0.14.0
+	gopkg.in/yaml.v2 v2.4.0
+	gotest.tools/v3 v3.5.1
+	tags.cncf.io/container-device-interface v0.6.2
 )
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect // gomodjail:confined
-	github.com/Microsoft/go-winio v0.6.1 // indirect // gomodjail:confined
-	github.com/Microsoft/hcsshim v0.11.4 // indirect // gomodjail:confined
-	github.com/beorn7/perks v1.0.1 // indirect // gomodjail:confined
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect // gomodjail:confined
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect // gomodjail:confined
-	github.com/containerd/log v0.1.0 // indirect // gomodjail:confined
-	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c
-	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect // gomodjail:confined
-	github.com/docker/go-metrics v0.0.1 // indirect // gomodjail:confined
-	github.com/felixge/httpsnoop v1.0.4 // indirect // gomodjail:confined
-	github.com/go-logr/logr v1.4.1 // indirect // gomodjail:confined
-	github.com/go-logr/stdr v1.2.2 // indirect // gomodjail:confined
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/Microsoft/hcsshim v0.11.4 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	// gomodjail:unconfined
+	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
+	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	// gomodjail:unconfined
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect // gomodjail:confined
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect // gomodjail:confined
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect // gomodjail:confined
-	github.com/klauspost/compress v1.17.4 // indirect // gomodjail:confined
-	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect // gomodjail:confined
-	github.com/miekg/pkcs11 v1.1.1 // indirect // gomodjail:confined
-	github.com/moby/docker-image-spec v1.3.1 // indirect // gomodjail:confined
-	github.com/moby/sys/symlink v0.2.0 // indirect // gomodjail:confined
-	github.com/moby/sys/user v0.1.0 // indirect // gomodjail:confined
-	github.com/prometheus/client_golang v1.17.0 // indirect // gomodjail:confined
-	github.com/prometheus/client_model v0.5.0 // indirect // gomodjail:confined
-	github.com/prometheus/common v0.44.0 // indirect // gomodjail:confined
-	github.com/prometheus/procfs v0.12.0 // indirect // gomodjail:confined
-	github.com/rivo/uniseg v0.2.0 // indirect // gomodjail:confined
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect // gomodjail:confined
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect // gomodjail:confined
-	go.etcd.io/etcd/raft/v3 v3.5.6 // indirect // gomodjail:confined
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 // indirect // gomodjail:confined
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect // gomodjail:confined
-	go.opentelemetry.io/proto/otlp v1.0.0 // indirect // gomodjail:confined
-	golang.org/x/crypto v0.21.0 // indirect // gomodjail:confined
-	golang.org/x/mod v0.14.0 // indirect // gomodjail:confined
-	golang.org/x/net v0.23.0 // indirect // gomodjail:confined
-	golang.org/x/time v0.3.0 // indirect // gomodjail:confined
-	golang.org/x/tools v0.16.0 // indirect // gomodjail:confined
-	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect // gomodjail:confined
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b // indirect // gomodjail:confined
+	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/miekg/pkcs11 v1.1.1 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/sys/symlink v0.2.0 // indirect
+	github.com/moby/sys/user v0.1.0 // indirect
+	github.com/prometheus/client_golang v1.17.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.44.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	go.etcd.io/etcd/raft/v3 v3.5.6 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
+	golang.org/x/mod v0.14.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.16.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b // indirect
+	// gomodjail:unconfined
 	google.golang.org/grpc v1.60.1 // indirect
+	// gomodjail:unconfined
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/mod v0.23.0
 	golang.org/x/sys v0.30.0
+	gotest.tools/v3 v3.5.2
 )
 
 require (
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/net v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-seccomp-bpf v1.5.0 h1:gJV+U1iP+YC70ySyGUUNk2YLJW5/IkEw4FZBJfW8ZZY=
 github.com/elastic/go-seccomp-bpf v1.5.0/go.mod h1:umdhQ/3aybliBF2jjiZwS492I/TOKz+ZRvsLT3hVe1o=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -23,3 +25,5 @@ golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=

--- a/pkg/profile/fromgomod/fromgomod_test.go
+++ b/pkg/profile/fromgomod/fromgomod_test.go
@@ -1,0 +1,95 @@
+package fromgomod
+
+import (
+	"testing"
+
+	"github.com/AkihiroSuda/gomodjail/pkg/profile"
+	"golang.org/x/mod/modfile"
+	"gotest.tools/v3/assert"
+)
+
+func TestFromGoMod(t *testing.T) {
+	type testCase struct {
+		name     string
+		goMod    string
+		expected map[string]profile.Policy
+	}
+	testCases := []testCase{
+		{
+			name: "basic",
+			goMod: `
+module example.com/foo
+
+go 1.23
+
+require (
+	example.com/mod100 v1.2.3 // gomodjail:confined
+	example.com/mod101 v1.2.3
+	// gomodjail:confined
+	example.com/mod102 v1.2.3
+	example.com/mod103 v1.2.3
+)
+
+require (
+	example.com/mod200 v1.2.3 // indirect
+	example.com/mod201 v1.2.3 // indirect; gomodjail:confined
+	example.com/mod202 v1.2.3 // indirect // gomodjail:confined
+	// gomodjail:confined
+	example.com/mod203 v1.2.4 // indirect
+)
+`,
+			expected: map[string]string{
+				"example.com/mod100": "confined",
+				"example.com/mod102": "confined",
+				"example.com/mod201": "confined",
+				"example.com/mod202": "confined",
+				"example.com/mod203": "confined",
+			},
+		},
+
+		{
+			name: "global",
+			goMod: `
+// gomodjail:confined
+module example.com/foo
+
+go 1.23
+
+require (
+	example.com/mod100 v1.2.3
+	example.com/mod101 v1.2.3 // gomodjail:unconfined
+	example.com/mod102 v1.2.3
+	// gomodjail:unconfined
+	example.com/mod103 v1.2.3
+)
+
+require (
+	// gomodjail:unconfined
+	example.com/mod200 v1.2.3 // indirect
+	example.com/mod201 v1.2.3 // indirect
+	example.com/mod202 v1.2.3 // indirect
+)
+
+// policy cannot be specified here because the parser ignores
+// the comment lines here
+require (
+)
+`,
+			expected: map[string]string{
+				"example.com/mod100": "confined",
+				"example.com/mod102": "confined",
+				"example.com/mod201": "confined",
+				"example.com/mod202": "confined",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mod, err := modfile.Parse(tc.name, []byte(tc.goMod), nil)
+			assert.NilError(t, err)
+			prof := profile.New()
+			assert.NilError(t, FromGoMod(mod, prof))
+			assert.DeepEqual(t, tc.expected, prof.Modules)
+		})
+	}
+}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -9,10 +9,12 @@ import (
 type Policy = string
 
 const (
-	PolicyConfined = "confined"
+	PolicyUnconfined = "unconfined"
+	PolicyConfined   = "confined"
 )
 
 var KnownPolicies = []Policy{
+	PolicyUnconfined,
 	PolicyConfined,
 }
 


### PR DESCRIPTION
e.g.,
```go-module
// gomodjail:confined
module example.com/foo

go 1.23

require (
        example.com/mod100 v1.2.3
        example.com/mod101 v1.2.3 // gomodjail:unconfined
        example.com/mod102 v1.2.3
        // gomodjail:unconfined
        example.com/mod103 v1.2.3
)

require (
        // gomodjail:unconfined
        example.com/mod200 v1.2.3 // indirect
        example.com/mod201 v1.2.3 // indirect
)

// policy cannot be specified here because the parser ignores
// the comment lines here
require (
)
```

This makes the following modules confined: `mod100`, `mod102`, and `mod201`.