### PR TITLE
Linux: Allow stripping symbol table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,20 @@ jobs:
         include:
           - runner: ubuntu-24.04  # Intel
             go: 1.24.x
+            build_mode: ""
+          - runner: ubuntu-24.04  # Intel
+            go: 1.24.x
+            build_mode: "strip"
           - runner: macos-13  # Intel
             go: 1.24.x
+            build_mode: ""
           - runner: macos-15  # ARM
             # libgomodjail_hook_darwin is sensitive to Go version
             go: 1.23.x
+            build_mode: ""
           - runner: macos-15  # ARM
             go: 1.24.x
+            build_mode: ""
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     steps:
@@ -40,10 +47,16 @@ jobs:
         uses: golangci/golangci-lint-action@v6
       - name: Smoke test
         timeout-minutes: 5
+        env:
+          BUILD_MODE: ${{ matrix.build_mode }}
         run: |
           set -eux
           cd examples/victim
-          go build
+          if [ "${BUILD_MODE}" = "strip" ]; then
+            go build -ldflags="-s -w"
+          else
+            go build
+          fi
           gomodjail run --go-mod=go.mod -- ./victim
       - name: "Smoke test: docker (not dockerd)"
         if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ level=WARN msg=***Blocked*** syscall=pidfd_open module=github.com/AkihiroSuda/go
 
 ## Caveats
 - Not applicable to a Go binary built by non-trustworthy thirdparty, as the symbol information might be faked.
-- Not applicable to a Go binary built with `-ldflags="-s"` (disable symbol table)
 - Not applicable to a Go module that use:
   - [`unsafe`](https://pkg.go.dev/unsafe)
   - [`reflect`](https://pkg.go.dev/reflect)
@@ -92,6 +91,7 @@ level=WARN msg=***Blocked*** syscall=pidfd_open module=github.com/AkihiroSuda/go
 - This is not a panacea; there can be other loopholes too.
 
 macOS:
+- Not applicable to a Go binary built with `-ldflags="-s"` (disable symbol table)
 - The protection can be arbitraliry disabled by unsetting an environment variable `DYLD_INSERT_LIBRARIES`.
 - Only works with the following versions of Go:
   - 1.22


### PR DESCRIPTION
Stripped binaries still have the `.gopclntab` section, so they seem to still work.