### PR TITLE
Add `gomodjail pack FILE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,27 +102,8 @@ macOS:
 
 ## Advanced topics
 ### Advanced usage
-See `gomodjail run --help`
-
-```console
-$ gomodjail run --help
-Run a Go program with confinement
-
-Usage:
-  gomodjail run COMMAND...
-
-Examples:
-TBD
-
-Flags:
-      --go-mod gomodjail:confined   go.mod file with comment lines like gomodjail:confined
-  -h, --help                        help for run
-      --no-policy                   Allow running without any policy (useful only for debugging)
-      --policy stringToString       e.g., example.com/module=confined (default [])
-
-Global Flags:
-      --debug   debug mode [$DEBUG]
-```
+- To create a self-extract archive of gomodjail with a target program, run `gomodjail pack --go-mod=go.mod PROGRAM`.
+  Needs [`makeself`](https://makeself.io) to be installed (`apt install makeself`).
 
 ### How it works
 Linux:
@@ -139,7 +120,6 @@ macOS:
 
 ### Future works
 - Automatically detect non-applicable modules (explained in [Caveats](#caveats)).
-- Support embedding gomodjail in a target program
 - Apply landlock in addition to seccomp. Depends on `SECCOMP_IOCTL_NOTIF_ADDFD`.
 - Modify the source code of the Go runtime, so as to remove necessity of using `seccomp` (Linux) and `DYLD_INSERT_LIBRARIES` (macOS).
 

--- a/cmd/gomodjail/commands/pack/pack.go
+++ b/cmd/gomodjail/commands/pack/pack.go
@@ -1,0 +1,126 @@
+package pack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/AkihiroSuda/gomodjail/pkg/cp"
+	"github.com/spf13/cobra"
+)
+
+func Example() string {
+	return `  # Pack nerdctl with gomodjail
+  gomodjail pack --go-mod=go.mod /usr/local/bin/nerdctl
+`
+}
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "pack FILE",
+		Short:                 "Pack a Go program with gomodjail",
+		Example:               Example(),
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  action,
+		DisableFlagsInUseLine: true,
+	}
+	flags := cmd.Flags()
+	flags.String("go-mod", "", "go.mod file with comment lines like `gomodjail:confined`")
+	return cmd
+}
+
+func action(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	flags := cmd.Flags()
+	flagGoMod, err := flags.GetString("go-mod")
+	if err != nil {
+		return err
+	}
+	if flagGoMod == "" {
+		return errors.New("needs --go-mod")
+	}
+	prog := args[0]
+	progBase := filepath.Base(prog)
+	progAbs, err := filepath.Abs(prog)
+	if err != nil {
+		return err
+	}
+
+	selfExe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	makeself, err := exec.LookPath("makeself")
+	if err != nil {
+		return fmt.Errorf("%w (Hint: apt/dnf/brew install makeself)", err)
+	}
+
+	td, err := os.MkdirTemp("", "gomodjail-pack-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(td)
+
+	files := map[string]string{
+		"gomodjail": selfExe,
+		"go.mod":    flagGoMod,
+		progBase:    progAbs,
+	}
+	for dstBase, src := range files {
+		dst := filepath.Join(td, dstBase)
+		if err = cp.CopyFile(dst, src, 0o500); err != nil {
+			return fmt.Errorf("failed to copy %q to %q: %w", src, dst, err)
+		}
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	makeselfCmd := exec.CommandContext(ctx, makeself,
+		"--nomd5",
+		"--nocrc",
+		"--nocomp",
+		"--noprogress",
+		"--quiet",
+		"--packaging-date", "Thu Jan  1 09:00:00 AM JST 1970",
+		// TODO: make targetdir deterministic
+		".",
+		progBase+".gomodjail",
+		progBase+" with gomodjail",
+		"./gomodjail",
+		"run",
+		"--go-mod=go.mod",
+		"--",
+		progBase,
+	)
+	makeselfCmd.Dir = td
+	makeselfCmd.Stdout = cmd.OutOrStdout()
+	makeselfCmd.Stderr = cmd.ErrOrStderr()
+	slog.InfoContext(ctx, "Running makeself", "cmd", makeselfCmd.Args)
+	if err = makeselfCmd.Run(); err != nil {
+		return err
+	}
+
+	src := filepath.Join(td, progBase+".gomodjail")
+	dst := filepath.Join(oldWD, progBase+".gomodjail")
+	if err = cp.CopyFile(dst, src, 0o500); err != nil {
+		return fmt.Errorf("failed to copy %q to %q: %w", src, dst, err)
+	}
+	return patchMakeselfHeader(ctx, dst)
+}
+
+func patchMakeselfHeader(ctx context.Context, f string) error {
+	cmd := exec.CommandContext(ctx, "sed", "-i", `s/^quiet="n"/quiet="y"/`, f)
+	slog.InfoContext(ctx, "Patching makeself header", "cmd", cmd.Args)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w (%q)", err, string(out))
+	}
+	return nil
+}

--- a/cmd/gomodjail/main.go
+++ b/cmd/gomodjail/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/AkihiroSuda/gomodjail/cmd/gomodjail/commands/pack"
 	"github.com/AkihiroSuda/gomodjail/cmd/gomodjail/commands/run"
 	"github.com/AkihiroSuda/gomodjail/cmd/gomodjail/version"
 	"github.com/AkihiroSuda/gomodjail/pkg/envutil"
@@ -54,6 +55,7 @@ func newRootCommand() *cobra.Command {
 
 	cmd.AddCommand(
 		run.New(),
+		pack.New(),
 	)
 	return cmd
 }

--- a/pkg/cp/cp.go
+++ b/pkg/cp/cp.go
@@ -1,0 +1,23 @@
+package cp
+
+import (
+	"io"
+	"os"
+)
+
+func CopyFile(dst, src string, perm os.FileMode) error {
+	srcF, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcF.Close()
+	dstF, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		return err
+	}
+	defer dstF.Close()
+	if _, err = io.Copy(dstF, srcF); err != nil {
+		return err
+	}
+	return dstF.Close()
+}


### PR DESCRIPTION
`gomodjail pack --go-mod=go.mod FILE` packs the Go program `FILE` with gomodjail.