### PR TITLE
respect main module name in go.mod

### DIFF
--- a/pkg/profile/fromgomod/fromgomod.go
+++ b/pkg/profile/fromgomod/fromgomod.go
@@ -12,6 +12,7 @@ import (
 )
 
 func FromGoMod(mod *modfile.File, prof *profile.Profile) error {
+	prof.Module = mod.Module.Mod.Path
 	currentDefaultPolicy := profile.PolicyUnconfined
 
 	for _, c := range append(mod.Module.Syntax.Before, mod.Module.Syntax.Suffix...) {

--- a/pkg/profile/fromgomod/fromgomod_test.go
+++ b/pkg/profile/fromgomod/fromgomod_test.go
@@ -93,6 +93,7 @@ require (
 			assert.NilError(t, err)
 			prof := profile.New()
 			assert.NilError(t, FromGoMod(mod, prof))
+			assert.DeepEqual(t, "example.com/foo", prof.Module)
 			assert.DeepEqual(t, tc.expected, prof.Modules)
 		})
 	}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -8,29 +8,31 @@ import (
 
 func TestProfile(t *testing.T) {
 	prof := New()
+	const mainMod = "example.com/blah/v2"
+	prof.Module = mainMod
 	prof.Modules["example.com/foo"] = PolicyConfined
 	prof.Modules["example.com/foobaz"] = PolicyConfined
 	assert.NilError(t, prof.Validate())
 	assert.DeepEqual(t, &Confinment{
 		Module: "example.com/foo",
 		Policy: PolicyConfined,
-	}, prof.Confined("example.com/foo"))
+	}, prof.Confined(mainMod, "example.com/foo"))
 	assert.DeepEqual(t, &Confinment{
 		Module: "example.com/foo",
 		Policy: PolicyConfined,
-	}, prof.Confined("example.com/foo/bar"))
+	}, prof.Confined(mainMod, "example.com/foo/bar"))
 	assert.DeepEqual(t, &Confinment{
 		Module: "example.com/foo",
 		Policy: PolicyConfined,
-	}, prof.Confined("example.com/foo.fn"))
+	}, prof.Confined(mainMod, "example.com/foo.fn"))
 	assert.DeepEqual(t, &Confinment{
 		Module: "example.com/foo",
 		Policy: PolicyConfined,
-	}, prof.Confined("example.com/foo/bar.fn"))
-	assert.Assert(t, prof.Confined("example.com/foobar.fn") == nil)
+	}, prof.Confined(mainMod, "example.com/foo/bar.fn"))
+	assert.Assert(t, prof.Confined(mainMod, "example.com/foobar.fn") == nil)
 	assert.DeepEqual(t, &Confinment{
 		Module: "example.com/foobaz",
 		Policy: PolicyConfined,
-	}, prof.Confined("example.com/foobaz.fn"))
-	assert.Assert(t, prof.Confined("example.com/baz.fn") == nil)
+	}, prof.Confined(mainMod, "example.com/foobaz.fn"))
+	assert.Assert(t, prof.Confined(mainMod, "example.com/baz.fn") == nil)
 }

--- a/pkg/tracer/tracer_linux.go
+++ b/pkg/tracer/tracer_linux.go
@@ -173,6 +173,7 @@ func (tracer *tracer) handleSyscall(pid int, regs *regs.Regs) error {
 			return err
 		}
 		tracer.unwinders[filename] = uw
+		slog.Debug("registered an executable", "exe", filename, "mainModule", uw.BuildInfo.Main.Path)
 	}
 	if uw == nil { // No gosymtab
 		return nil
@@ -185,7 +186,7 @@ func (tracer *tracer) handleSyscall(pid int, regs *regs.Regs) error {
 	for i, e := range entries {
 		slog.Debug("stack", "entryNo", i, "entry", e.String())
 		pkgName := e.Func.PackageName()
-		if cf := tracer.profile.Confined(pkgName); cf != nil {
+		if cf := tracer.profile.Confined(uw.BuildInfo.Main.Path, pkgName); cf != nil {
 			slog.Warn("***Blocked***", "pid", pid, "exe", filename, "syscall", syscallName, "entry", e.String(), "module", cf.Module)
 			ret := -1 * int(unix.EPERM)
 			regs.SetRet(uint64(ret))

--- a/pkg/unwinder/unwinder_linux.go
+++ b/pkg/unwinder/unwinder_linux.go
@@ -4,6 +4,7 @@
 package unwinder
 
 import (
+	"debug/buildinfo"
 	"debug/elf"
 	"debug/gosym"
 	"fmt"
@@ -13,7 +14,8 @@ import (
 )
 
 type Unwinder struct {
-	Symtab *gosym.Table
+	Symtab    *gosym.Table
+	BuildInfo *buildinfo.BuildInfo
 }
 
 func New(binary string) (*Unwinder, error) {
@@ -52,8 +54,14 @@ func New(binary string) (*Unwinder, error) {
 		return nil, err
 	}
 
+	buildInfo, err := buildinfo.ReadFile(binary)
+	if err != nil {
+		return nil, err
+	}
+
 	u := &Unwinder{
-		Symtab: symtab,
+		Symtab:    symtab,
+		BuildInfo: buildInfo,
 	}
 	return u, nil
 }


### PR DESCRIPTION
Relates to issue #39.

A policy for nerdctl (`github.com/containerd/nerdctl/v2`) should not affect buildctl (`github.com/moby/buildkit`) that is invoked from nerdctl.