### PR TITLE
unpack: cache: avoid using XDG_RUNTIME_DIR

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strconv"
 
 	"github.com/AkihiroSuda/gomodjail/pkg/env"
 )
@@ -39,23 +37,10 @@ func sha256sum(b []byte) string {
 
 // Home candidates are:
 // - $GOMODJAIL_CACHE_HOME
-// - $XDG_RUNTIME_DIR/gomodjail
-// - $TMPDIR/gomodjail (macOS)
 // - $XDG_CACHE_HOME/gomodjail
 func Home() (string, error) {
 	if cacheHome := os.Getenv(env.CacheHome); cacheHome != "" {
 		return cacheHome, nil
-	}
-	if xrd := xdgRuntimeDir(); xrd != "" {
-		cacheHome := filepath.Join(xrd, "gomodjail")
-		return cacheHome, nil
-	}
-	if runtime.GOOS == "darwin" {
-		// macOS allocates a unique TMPDIR per user
-		if td := os.Getenv("TMPDIR"); td != "" {
-			cacheHome := filepath.Join(td, "gomodjail")
-			return cacheHome, nil
-		}
 	}
 	osCacheHome, err := os.UserCacheDir()
 	if err != nil {
@@ -63,15 +48,4 @@ func Home() (string, error) {
 	}
 	cacheHome := filepath.Join(osCacheHome, "gomodjail")
 	return cacheHome, nil
-}
-
-func xdgRuntimeDir() string {
-	if xrd := os.Getenv("XDG_RUNTIME_DIR"); xrd != "" {
-		return xrd
-	}
-	xrd := filepath.Join("run", "user", strconv.Itoa(os.Geteuid()))
-	if _, err := os.Stat(xrd); err == nil {
-		return xrd
-	}
-	return ""
 }

--- a/pkg/ziputil/ziputil.go
+++ b/pkg/ziputil/ziputil.go
@@ -71,13 +71,9 @@ func FindSelfExtractArchive() (*zip.ReadCloser, error) {
 }
 
 func Unzip(dir string, zr *zip.ReadCloser) ([]fs.FileInfo, error) {
-	// https://specifications.freedesktop.org/basedir-spec/latest/#variables
-	// To ensure that your files are not removed, they should have their access time timestamp modified at least once every 6 hours of monotonic time
-	// or the 'sticky' bit should be set on the file.
-	if err := os.MkdirAll(dir, 0o755|os.ModeSticky); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
-
 	res := make([]fs.FileInfo, len(zr.File))
 	for i, f := range zr.File {
 		if err := unzip1(dir, f); err != nil {
@@ -115,7 +111,7 @@ func unzip1(dir string, f *zip.File) error {
 	wPathTmp := fmt.Sprintf("%s.pid-%d", wPath, os.Getpid())
 	defer os.RemoveAll(wPathTmp) //nolint:errcheck
 
-	w, err := os.OpenFile(wPathTmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fi.Mode()|os.ModeSticky)
+	w, err := os.OpenFile(wPathTmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fi.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ephemeral cache is problematic for `nerdctl run --restart` when the host is rebooted