### PR TITLE
Support stripped binaries on macOS (ARM)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
           - runner: macos-26  # ARM
             go: 1.25.x
             build_mode: ""
+          - runner: macos-26  # ARM
+            go: 1.25.x
+            build_mode: "strip"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     steps:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ level=WARN msg=***Blocked*** syscall=pidfd_open module=github.com/AkihiroSuda/go
 - This is not a panacea; there can be other loopholes too.
 
 macOS:
-- Not applicable to a Go binary built with `-ldflags="-s"` (disable symbol table)
 - The protection can be arbitraliry disabled by unsetting an environment variable `DYLD_INSERT_LIBRARIES`.
 - Only works with the following versions of Go:
   - 1.22
@@ -100,6 +99,9 @@ macOS:
   - 1.25
 - Not applicable to a Go module that use:
   - [`syscall.Syscall`, `syscall.RawSyscall`, etc.](https://pkg.go.dev/syscall)
+
+macOS on Intel:
+- Not applicable to a Go binary built with `-ldflags="-s"` (disable symbol table)
 
 ## Advanced topics
 ### Advanced usage


### PR DESCRIPTION
Fix #32

g is now fetched without depending on the symtab.
