### PR TITLE
libgomodjail_hook_darwin: support Go 1.24.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ macOS:
 - Only works with the following versions of Go:
   - 1.22
   - 1.23
-  - 1.24
+  - 1.24 (excluding 1.24.0-1.24.5)
   - 1.25
   - 1.26 (tested with rc1)
 - Not applicable to a Go module that use:

--- a/libgomodjail_hook_darwin/libgomodjail_hook_darwin.c
+++ b/libgomodjail_hook_darwin/libgomodjail_hook_darwin.c
@@ -73,13 +73,12 @@ static struct go_runtime_offset go_runtime_offsets[] = {
         .m_libcallpc = 872,
         .m_libcallsp = 880,
     },
-
     {
-        /* go1.24.0 */
+        /* go1.24.11 */
         .version_prefix = "go1.24",
         .g_m = 48,
-        .m_libcallpc = 856,
-        .m_libcallsp = 864,
+        .m_libcallpc = 880, // 856 in go1.24.0-go1.24.5
+        .m_libcallsp = 888, // 864 in go1.24.0-go1.24.5
     },
     {
         /* go1.23.6 */


### PR DESCRIPTION
Fix #88 