### PR TITLE
Revert "CI: temporarily disable release check for PRs"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       - 'master'
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   release:
     env:


### PR DESCRIPTION
Revert:
- #109 

I was overreacting to https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation .
We were not vulnerable because we had no workflows that permitted triggers from `pull_request_target`, `issue_comment`, or anything similar events.