### PR TITLE
regs: arm64: return all six syscall argument registers in Args()

### DIFF
--- a/pkg/dynamic/tracer/regs/regs_linux_arm64.go
+++ b/pkg/dynamic/tracer/regs/regs_linux_arm64.go
@@ -5,7 +5,7 @@ func (regs *Regs) Syscall() uint64 {
 }
 
 func (regs *Regs) Args() []uint64 {
-	return regs.Regs[0:5]
+	return regs.Regs[0:6]
 }
 
 func (regs *Regs) SetSyscall(v uint64) {

--- a/pkg/dynamic/tracer/regs/regs_test.go
+++ b/pkg/dynamic/tracer/regs/regs_test.go
@@ -1,0 +1,13 @@
+//go:build linux && (amd64 || arm64)
+
+package regs
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestArgsArity(t *testing.T) {
+	assert.Equal(t, len((&Regs{}).Args()), 6)
+}


### PR DESCRIPTION
## Summary

`Regs.Args()` on arm64 returned only **five** syscall arguments (`Regs[0:5]`, i.e. x0-x4), while the Linux arm64 syscall ABI passes up to **six** arguments in registers x0-x5 (see `syscall(2)`). The amd64 implementation already exposes all six argument registers, so the two architectures disagreed on the arity of an identical API. This changes the slice to `Regs[0:6]`.

Fixes #133

## Changes

- `pkg/dynamic/tracer/regs/regs_linux_arm64.go`: return `Regs[0:6]` (x0-x5) instead of `Regs[0:5]`
- `pkg/dynamic/tracer/regs/regs_test.go`: add `TestArgsArity` asserting `len(Args()) == 6` on every supported architecture (amd64/arm64), keeping the two implementations aligned

## Testing

- `gofmt -l`: clean
- `go vet ./pkg/dynamic/tracer/regs/`: clean
- `GOARCH=arm64 go build ./pkg/dynamic/tracer/regs/`: OK
- `GOARCH=amd64 go build ./pkg/dynamic/tracer/regs/`: OK
- `go test -v ./pkg/dynamic/tracer/regs/`: PASS