### PR TITLE
fix: match the go.mod's own annotation spacing

### DIFF
--- a/pkg/profile/gomodedit/gomodedit.go
+++ b/pkg/profile/gomodedit/gomodedit.go
@@ -16,15 +16,23 @@ import (
 // namespace is the directive-comment namespace, as in "// gomodjail:confined".
 const namespace = "gomodjail"
 
+// defaultPrefix opens a newly inserted annotation comment when the file has
+// no existing annotation whose style to copy. It is the style used by the
+// README and the docs.
+const defaultPrefix = "// "
+
 // SetPolicy sets the gomodjail policy annotation for the given module on its
 // require line(s) in mf. An existing per-line annotation is rewritten in
 // place; otherwise the annotation is added as a per-line comment — appended
 // to the suffix comment, or, for `// indirect` requires, on its own line
 // above (the suffix stays exactly `// indirect` for other toolchains) — so
-// that it overrides any block- or file-level default. It reports whether the
-// file changed, and errors if the module has no require line. The caller
-// renders the result with modfile.Format.
+// that it overrides any block- or file-level default. A newly inserted comment
+// copies the spacing of the annotations already in the file
+// ("//gomodjail:x" vs "// gomodjail:x"). It reports whether the file changed,
+// and errors if the module has no require line. The caller renders the result
+// with modfile.Format.
 func SetPolicy(mf *modfile.File, module, policy string) (bool, error) {
+	prefix := annotationPrefix(mf.Syntax)
 	found := false
 	changed := false
 	for _, req := range mf.Require {
@@ -32,7 +40,7 @@ func SetPolicy(mf *modfile.File, module, policy string) (bool, error) {
 			continue
 		}
 		found = true
-		if setPolicyOnLine(req.Syntax, policy, req.Indirect) {
+		if setPolicyOnLine(req.Syntax, policy, req.Indirect, prefix) {
 			changed = true
 		}
 	}
@@ -42,7 +50,7 @@ func SetPolicy(mf *modfile.File, module, policy string) (bool, error) {
 	return changed, nil
 }
 
-func setPolicyOnLine(line *modfile.Line, policy string, indirect bool) bool {
+func setPolicyOnLine(line *modfile.Line, policy string, indirect bool, prefix string) bool {
 	annotation := namespace + ":" + policy
 	rewrote := false
 	changed := false
@@ -72,13 +80,66 @@ func setPolicyOnLine(line *modfile.Line, policy string, indirect bool) bool {
 		// keep it byte-for-byte intact and put the annotation on its own line
 		// above instead. A per-line Before annotation still overrides block-
 		// and file-level defaults (the suffix carries no annotation to beat it).
-		line.Before = append(line.Before, modfile.Comment{Token: "//" + annotation})
+		line.Before = append(line.Before, modfile.Comment{Token: prefix + annotation})
 	case n > 0:
 		line.Suffix[n-1].Token = appendToComment(line.Suffix[n-1].Token, annotation)
 	default:
-		line.Suffix = append(line.Suffix, modfile.Comment{Token: "// " + annotation, Suffix: true})
+		line.Suffix = append(line.Suffix, modfile.Comment{Token: prefix + annotation, Suffix: true})
 	}
 	return true
+}
+
+// annotationPrefix reports how the annotations already in the file are
+// written — "//" plus whatever whitespace separates it from "gomodjail:" —
+// so that an inserted annotation matches the surrounding style instead of
+// imposing one. The first annotation comment in file order wins; a file with
+// none (or with annotations only embedded in longer comment text) gets
+// defaultPrefix.
+func annotationPrefix(syntax *modfile.FileSyntax) string {
+	prefix := defaultPrefix
+	found := false
+	visit := func(comments *modfile.Comments) {
+		if found || comments == nil {
+			return
+		}
+		for _, group := range [][]modfile.Comment{comments.Before, comments.Suffix, comments.After} {
+			for _, c := range group {
+				if p, ok := commentPrefix(c.Token); ok {
+					prefix, found = p, true
+					return
+				}
+			}
+		}
+	}
+	visit(&syntax.Comments)
+	for _, stmt := range syntax.Stmt {
+		visit(stmt.Comment())
+		if block, ok := stmt.(*modfile.LineBlock); ok {
+			visit(block.LParen.Comment())
+			for _, line := range block.Line {
+				visit(line.Comment())
+			}
+			visit(block.RParen.Comment())
+		}
+	}
+	return prefix
+}
+
+// commentPrefix returns the "//" and separating whitespace of a comment token
+// that opens with a gomodjail annotation, e.g. "//" for "//gomodjail:confined"
+// and "// " for "// gomodjail:confined". ok is false for any other comment: an
+// annotation buried mid-comment says nothing about how a standalone one would
+// be spaced.
+func commentPrefix(token string) (string, bool) {
+	rest, ok := strings.CutPrefix(token, "//")
+	if !ok {
+		return "", false
+	}
+	space := spanFunc(rest, unicode.IsSpace)
+	if !strings.HasPrefix(rest[space:], namespace+":") {
+		return "", false
+	}
+	return token[:len(token)-len(rest)+space], true
 }
 
 // rewriteToken replaces every "gomodjail:<policy>" field of a comment token

--- a/pkg/profile/gomodedit/gomodedit_test.go
+++ b/pkg/profile/gomodedit/gomodedit_test.go
@@ -128,7 +128,7 @@ require example.com/dep v1.0.0 // indirect
 `
 	out, policies, changed := setPolicy(t, goMod, "example.com/dep", "unconfined")
 	assert.Assert(t, changed)
-	assert.Assert(t, strings.Contains(out, "//gomodjail:unconfined\nrequire example.com/dep v1.0.0 // indirect"), "got %q", out)
+	assert.Assert(t, strings.Contains(out, "// gomodjail:unconfined\nrequire example.com/dep v1.0.0 // indirect"), "got %q", out)
 	assert.Equal(t, policies["example.com/dep"], "")
 
 	mf, err := modfile.Parse("go.mod", []byte(out), nil)
@@ -153,7 +153,7 @@ require (
 `
 	out, policies, changed := setPolicy(t, goMod, "example.com/dep", "unconfined")
 	assert.Assert(t, changed)
-	assert.Assert(t, strings.Contains(out, "\t//gomodjail:unconfined\n\texample.com/dep v1.0.0 // indirect"), "got %q", out)
+	assert.Assert(t, strings.Contains(out, "\t// gomodjail:unconfined\n\texample.com/dep v1.0.0 // indirect"), "got %q", out)
 	assert.Equal(t, policies["example.com/dep"], "")
 	assert.Equal(t, policies["example.com/other"], "confined")
 
@@ -214,4 +214,56 @@ func TestSetPolicyUnknownModule(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = SetPolicy(mf, "example.com/dep", "unconfined")
 	assert.ErrorContains(t, err, "no require line")
+}
+
+// TestSetPolicyMatchesFileSpacing: an inserted annotation copies the spacing
+// the file already uses, rather than imposing gomodjail's own house style.
+// nerdctl writes "//gomodjail:confined"; adding "// gomodjail:unconfined" to
+// such a file is an unsolicited whitespace change in the diff.
+// https://github.com/containerd/nerdctl/pull/5192#discussion_r3964205659
+func TestSetPolicyMatchesFileSpacing(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		goMod string
+		want  string
+	}{
+		{
+			name:  "file default, direct require",
+			goMod: "//gomodjail:confined\nmodule example.com/app\n\ngo 1.23\n\nrequire example.com/dep v1.0.0\n",
+			want:  "require example.com/dep v1.0.0 //gomodjail:unconfined",
+		},
+		{
+			name:  "file default, indirect require",
+			goMod: "//gomodjail:confined\nmodule example.com/app\n\ngo 1.23\n\nrequire example.com/dep v1.0.0 // indirect\n",
+			want:  "//gomodjail:unconfined\nrequire example.com/dep v1.0.0 // indirect",
+		},
+		{
+			name:  "block default",
+			goMod: "module example.com/app\n\ngo 1.23\n\n//gomodjail:confined\nrequire (\n\texample.com/dep v1.0.0\n\texample.com/other v1.0.0\n)\n",
+			want:  "\texample.com/dep v1.0.0 //gomodjail:unconfined",
+		},
+		{
+			name:  "spaced style is copied too",
+			goMod: "// gomodjail:confined\nmodule example.com/app\n\ngo 1.23\n\nrequire example.com/dep v1.0.0\n",
+			want:  "require example.com/dep v1.0.0 // gomodjail:unconfined",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, policies, changed := setPolicy(t, tc.goMod, "example.com/dep", "unconfined")
+			assert.Assert(t, changed)
+			assert.Assert(t, strings.Contains(out, tc.want), "want %q in %q", tc.want, out)
+			assert.Equal(t, policies["example.com/dep"], "")
+		})
+	}
+}
+
+// TestSetPolicyDefaultSpacing: with no annotation anywhere to copy — the
+// module is confined by something other than a comment in this go.mod, or the
+// caller is annotating a fresh file — the documented "// gomodjail:x" style
+// is used.
+func TestSetPolicyDefaultSpacing(t *testing.T) {
+	const goMod = "module example.com/app\n\ngo 1.23\n\nrequire example.com/dep v1.0.0\n"
+	out, _, changed := setPolicy(t, goMod, "example.com/dep", "unconfined")
+	assert.Assert(t, changed)
+	assert.Assert(t, strings.Contains(out, "require example.com/dep v1.0.0 // gomodjail:unconfined"), "got %q", out)
 }


### PR DESCRIPTION
`gomodjail fix` inserted a new annotation from a hardcoded string: `"// " + annotation` for the suffix branch, `"//" + annotation` for the `// indirect` branch. A go.mod written as `//gomodjail:confined` therefore got back `// gomodjail:unconfined`, and one written as `// gomodjail:confined` got `//gomodjail:unconfined` on indirect requires -- an unsolicited whitespace change in the diff either way.

SetPolicy now sniffs the file's existing style once (first comment opening with a gomodjail annotation, in file order) and both insertion branches use it; a file with no annotation to copy keeps the documented `// gomodjail:x`. Annotations already on the require line were never affected -- rewriteToken preserves their spacing.

Reported at
https://github.com/containerd/nerdctl/pull/5192#discussion_r3964205659